### PR TITLE
Mostly fix the login issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --port 8001",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/src/components/MessageForm.vue
+++ b/src/components/MessageForm.vue
@@ -119,17 +119,14 @@ import '@/assets/css/submissions.css';
 export default {
   name: "MessageForm",
   computed: {
-      ...mapGetters(["getUserName", "getMainData", "getExtraData", "getMainTableName", "getMainTableHeader", "getCsrfToken"]),
+      ...mapGetters(["getUserName", "getMainData", "getExtraData", "getMainTableName", "getMainTableHeader", "getCsrfToken", "getWritableTopics"]),
       formattedMessage() {
       return this.formatMessage(this.message);
     }
   },
   mounted() {
-    // Get available topics
-    axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/topics/")
-      .then((response) => (this.topicOptions = response.data.write, this.topic = response.data.write[0]))
-      .catch((error) => console.log(error));
+    this.topicOptions = this.getWritableTopics;
+    this.topic = this.topicOptions[0];
     this.user = this.getUserName;
   },
   props: {
@@ -148,7 +145,7 @@ export default {
       topicOptions: [],
       message: '',
       eventId: '',
-      user: 'Hermes User.guest',
+      user: 'HERMES Guest',
       fileInput: null,
       csvHeader: {
           id: 'csv-header',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,9 @@ export default new Vuex.Store({
     name: '',
     header: '',
     username: 'HERMES Guest',
+    writable_topics: ['hermes.test'],
     csrf_token: '',
+    mid_login: false
   },
   getters: {
     getMainData(state) {
@@ -29,8 +31,14 @@ export default new Vuex.Store({
     getUserName(state) {
       return state.username;
     },
+    getWritableTopics(state) {
+      return state.writable_topics;
+    },
     getCsrfToken(state) {
       return state.csrf_token;
+    },
+    getMidLogin(state) {
+      return state.mid_login;
     }
 
   },
@@ -51,9 +59,15 @@ export default new Vuex.Store({
     SET_USER_NAME(state, username) {
       state.username = username;
     },
+    SET_WRITABLE_TOPICS(state, writable_topics) {
+      state.writable_topics = writable_topics;
+    },
     SET_CSRF_TOKEN(state, csrf_token) {
       state.csrf_token = csrf_token;
     },
+    SET_MID_LOGIN(state, mid_login) {
+      state.mid_login = mid_login;
+    }
   },
   actions: {
   },

--- a/src/views/ViewMessages.vue
+++ b/src/views/ViewMessages.vue
@@ -274,7 +274,7 @@ export default {
     // Get available topics
     axios
       .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/topics/")
-      .then((response) => (this.topic_options = response.data.read))
+      .then((response) => (this.topic_options = response.data.topics))
       .catch((error) => console.log(error));
   },
   created() {


### PR DESCRIPTION
This requires hermes PR: https://github.com/LCOGT/hermes/pull/11 to be merged for the profile endpoint and some other fixes. This makes the login workflow functional, but there are still definitely some issues present, and I think its really fragile. 

In testing, I periodically get max retries exceeded errors when logging in hitting random hopauth stuff in the backend. If this happens, I basically have to manually type /logout_redirect/ into the frontend to get it to "reset" and hope it works the next time.

Also, logging in takes a solid minute of time, probably due to all the hopauth calls we make... Getting the writable topics for a user via /profile also takes an uncomfortable amount of time given its retrieving 3 topics for me.

That said, when running this with the PR when login works, it seems to function as we want (pulling the email and writable topics from the profile). 