### PR TITLE
Setup all api calls to use credentials in case hop stuff needs to be …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
       "devDependencies": {
         "@babel/core": "^7.12.16",
         "@babel/eslint-parser": "^7.12.16",
+        "@types/jquery": "^3.5.16",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "@vue/cli-plugin-babel": "~5.0.0",
@@ -2391,6 +2392,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
+      "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2462,6 +2472,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
@@ -14707,6 +14723,15 @@
         "@types/node": "*"
       }
     },
+    "@types/jquery": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
+      "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -14778,6 +14803,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "@types/sockjs": {
       "version": "0.3.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4303,9 +4303,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+      "version": "1.0.30001477",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001477.tgz",
+      "integrity": "sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ==",
       "dev": true,
       "funding": [
         {
@@ -4315,6 +4315,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -16168,9 +16172,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+      "version": "1.0.30001477",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001477.tgz",
+      "integrity": "sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
+    "@types/jquery": "^3.5.16",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "@vue/cli-plugin-babel": "~5.0.0",

--- a/src/assets/css/view.css
+++ b/src/assets/css/view.css
@@ -14,6 +14,10 @@
     max-width: 80%;
 }
 
+.text-center {
+    text-align: center;
+}
+
 .expand-button {
     max-width: 20%;
 }

--- a/src/components/NavHeader.vue
+++ b/src/components/NavHeader.vue
@@ -25,19 +25,18 @@
             <template #button-content>
               <em>{{ username }}</em>
             </template>
-            <b-dropdown-item
-              v-if="username === 'HERMES Guest'"
-              @click="authenticate"
-              >Log In</b-dropdown-item
-            >
-            <b-dropdown-item v-else @click="deauthenticate"
-              >Log Out</b-dropdown-item
-            >
-            <b-dropdown-item
-              v-if="username === 'HERMES Guest'"
-              @click="authenticate"
-              >Register</b-dropdown-item
-            >
+            <b-dropdown-item v-if="isLoggedIn" to="/profile">
+              Profile
+            </b-dropdown-item>
+            <b-dropdown-item v-if="!isLoggedIn" @click="authenticate">
+              Log In
+            </b-dropdown-item>
+            <b-dropdown-item v-else @click="deauthenticate">
+              Log Out
+            </b-dropdown-item>
+            <b-dropdown-item v-if="!isLoggedIn" @click="authenticate">
+              Register
+            </b-dropdown-item>
           </b-nav-item-dropdown>
         </b-navbar-nav>
       </b-collapse>
@@ -46,7 +45,6 @@
 </template>
 
 <script>
-import getEnv from "@/utils/env.js";
 import { mapGetters } from "vuex";
 import axios from "axios";
 import { logoutMixin } from '@/mixins/logoutMixin.js';
@@ -54,12 +52,12 @@ import { logoutMixin } from '@/mixins/logoutMixin.js';
 export default {
   mixins: [logoutMixin],
   computed: {
-    ...mapGetters(["getUserName", "getCsrfToken", "getMidLogin"]),
+    ...mapGetters(["getProfile", "getCsrfToken", "getMidLogin", "isLoggedIn", "getHermesUrl"]),
   },
   mounted() {
     // get CSRF token and store it for submission
     axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "get-csrf-token/", {
+      .get(this.getHermesUrl + "get-csrf-token/", {
           withCredentials: true,
         })
       .then((response) =>
@@ -74,30 +72,12 @@ export default {
 
     // If this is the first refresh after a login workflow, attempt to get the profile data and store it
     if (this.getMidLogin) {
-      axios
-        .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/profile/", {
-          withCredentials: true,
-        })
-        .then((response) => {
-          this.$store.commit("SET_USER_NAME", response.data["email"]);
-          this.$store.commit(
-            "SET_WRITABLE_TOPICS",
-            response.data["writable_topics"]
-          );
-          this.$store.commit("SET_MID_LOGIN", false);
-        })
-        .catch((error) => {
-          console.log(error);
-          if (error.response.status == 401){
-            this.deauthenticate();
-          }
-        });
+      this.$store.dispatch('getProfileData');
     }
-    this.username = this.getUserName;
+    this.username = this.getProfile.email;
   },
   watch: {
-    getUserName: function(value) {
-      console.log('username = ' + value);
+    "getProfile.email": function(value) {
       this.username = value;
     }
   },
@@ -105,12 +85,12 @@ export default {
     authenticate() {
       this.$store.commit("SET_MID_LOGIN", true);
       location.href =
-        getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "auth/authenticate/";
+        this.getHermesUrl + "auth/authenticate/";
     },
     deauthenticate() {
       this.logout();
       location.href =
-        getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "auth/logout/";
+        this.getHermesUrl + "auth/logout/";
     },
   },
   data() {

--- a/src/components/message-composition/HermesMessage.vue
+++ b/src/components/message-composition/HermesMessage.vue
@@ -31,7 +31,7 @@
                       :desc="''"
                       :hide="false"
                       :errors="errors.topic"
-                      :options="getWritableTopics"
+                      :options="getProfile.writable_topics"
                       @input="update"
                     />
                   </b-col>
@@ -280,6 +280,7 @@
             datatype="Message"
             :errors="getErrors('message_text', null)"
             :isEmpty="hermesMessage.message_text === ''"
+            ref="messageSection"
             :onlySimple=true
           >
             <b-tabs class="message-tabs" content-class="mt-2">
@@ -395,7 +396,8 @@
           'targets': true,
           'photometry': true,
           'astrometry': true,
-          'extra_data': true
+          'extra_data': true,
+          'message': true
         },
         referenceFields: [
           {
@@ -618,8 +620,15 @@
         id: 'hermes-message'
       };
     },
+    watch: {
+      'hermesMessage.data': function() {
+        for (const section in this.sectionShowSimple){
+          this.$refs[section + 'Section'].forceVisibility(false);
+        }
+      }
+    },
     computed: {
-      ...mapGetters(["getWritableTopics"]),
+      ...mapGetters(["getProfile"]),
       photometryFields: function () {
         return [
           {

--- a/src/components/message-composition/HermesMessage.vue
+++ b/src/components/message-composition/HermesMessage.vue
@@ -281,7 +281,6 @@
             ref="messageSection"
             :errors="getErrors('message_text', null)"
             :isEmpty="hermesMessage.message_text === ''"
-            ref="messageSection"
             :onlySimple=true
           >
             <b-tabs class="message-tabs" content-class="mt-2">
@@ -621,13 +620,6 @@
         show: true,
         id: 'hermes-message'
       };
-    },
-    watch: {
-      'hermesMessage.data': function() {
-        for (const section in this.sectionShowSimple){
-          this.$refs[section + 'Section'].forceVisibility(false);
-        }
-      }
     },
     computed: {
       ...mapGetters(["getProfile"]),

--- a/src/components/message-composition/MessageCompositionForm.vue
+++ b/src/components/message-composition/MessageCompositionForm.vue
@@ -30,13 +30,14 @@ import getEnv from "@/utils/env.js";
 import HermesMessage from '@/components/message-composition/HermesMessage.vue';
 import { OCSUtil } from 'ocs-component-lib';
 import { messageFormatMixin } from '@/mixins/messageFormatMixin.js';
+import { logoutMixin } from '@/mixins/logoutMixin.js';
 
 export default {
   name: 'MessageCompositionForm',
   components: {
     HermesMessage,
   },
-  mixins: [messageFormatMixin],
+  mixins: [messageFormatMixin, logoutMixin],
   props: {
     // The initial hermesMessage data. The basic structure of a hermes message should be included in the
     // object, including the base elements and an empty data element that can be filled in with various
@@ -69,7 +70,7 @@ export default {
   data: function() {
       return {
         topicOptions: [],
-        validateRequestManager: new OCSUtil.mostRecentRequestManager(this.getValidationRequest, this.onValidationSuccess),
+        validateRequestManager: new OCSUtil.mostRecentRequestManager(this.getValidationRequest, this.onValidationSuccess, this.onValidationFail),
         validationErrors: {},
         readyToSubmit: false,
         show: true
@@ -105,11 +106,17 @@ export default {
         this.readyToSubmit = true;
       }
     },
+    onValidationFail: function(jqXHR) {
+      if (jqXHR.status == 401) {
+        this.logout();
+      }
+    },
     submitToHop() {
       let payload = this.sanitizedMessageData();
       // Post message via axios
       axios({
         method: 'post',
+        withCredentials: true,
         // TODO: see if Vue.js can add the X-CSRFToken to all headers automagically
         headers: {'Content-Type': 'application/json',
                   'X-CSRFToken': this.getCsrfToken
@@ -123,6 +130,9 @@ export default {
       })
       .catch(error => {
         console.log(error);
+        if (error.response.status == 401){
+          this.logout();
+        }
       });
     },
     clearForm() {

--- a/src/components/message-composition/MessageCompositionForm.vue
+++ b/src/components/message-composition/MessageCompositionForm.vue
@@ -25,7 +25,6 @@ import _ from 'lodash';
 import $ from 'jquery';
 import axios from "axios";
 import { mapGetters } from "vuex";
-import getEnv from "@/utils/env.js";
 
 import HermesMessage from '@/components/message-composition/HermesMessage.vue';
 import { OCSUtil } from 'ocs-component-lib';
@@ -77,12 +76,12 @@ export default {
       };
   },
   mounted() {
-    this.topicOptions = this.getWritableTopics;
+    this.topicOptions = this.getProfile.writable_topics;
     this.hermesMessage.topic = this.topicOptions[0];
-    this.hermesMessage.submitter = this.getUserName;
+    this.hermesMessage.submitter = this.getProfile.email;
   },
   computed: {
-    ...mapGetters(["getUserName", "getCsrfToken", "getWritableTopics"]),
+    ...mapGetters(["getCsrfToken", "getProfile", "getHermesUrl"]),
   },
   methods: {
     validate: _.debounce(function() {
@@ -91,7 +90,7 @@ export default {
     getValidationRequest: function() {
       return $.ajax({
         type: 'POST',
-        url: new URL('/api/v0/' + this.submissionEndpoint + '/validate/', getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL")).href,
+        url: new URL('/api/v0/' + this.submissionEndpoint + '/validate/', this.getHermesUrl).href,
         data: JSON.stringify(this.sanitizedMessageData()),
         headers: {'X-CSRFToken': this.getCsrfToken},
         contentType: 'application/json'
@@ -121,10 +120,10 @@ export default {
         headers: {'Content-Type': 'application/json',
                   'X-CSRFToken': this.getCsrfToken
                   },
-        url: new URL('/api/v0/' + this.submissionEndpoint + '/', getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL")).href,
+        url: new URL('/api/v0/' + this.submissionEndpoint + '/', this.getHermesUrl).href,
         data: JSON.stringify(payload)
       })
-      .then(function () {
+      .then(() => {
         // log response, redirect to homepage
         location.href = '/';
       })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import '@babel/polyfill';
 import 'mutationobserver-shim';
 import Vue, { VNode } from "vue";
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
+import getEnv from "./utils/env.js";
 
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
@@ -26,6 +27,8 @@ $(document).ajaxSend(function(event, xhr, settings) {
     withCredentials: true
   };
 });
+
+store.commit('SET_HERMES_URL', getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL"));
 
 new Vue({
   router,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,20 @@ import vuetify from './plugins/vuetify';
 import store from './store';
 import 'ocs-component-lib/dist/ocs-component-lib.css';
 import { OCSComponentLib } from 'ocs-component-lib';
+import $ from 'jquery';
 
 Vue.use(BootstrapVue);
 Vue.use(OCSComponentLib);
 Vue.use(IconsPlugin);
 
 Vue.config.productionTip = false;
+
+// Add csrf protection and credentials to requests sent with ajax
+$(document).ajaxSend(function(event, xhr, settings) {
+  settings.xhrFields = {
+    withCredentials: true
+  };
+});
 
 new Vue({
   router,

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,4 +1,5 @@
 import { schemaDataMixin } from "./schemaDataMixin";
 import { messageFormatMixin } from "./messageFormatMixin";
+import { logoutMixin } from "./logoutMixin";
 
-export { schemaDataMixin, messageFormatMixin };
+export { logoutMixin, schemaDataMixin, messageFormatMixin };

--- a/src/mixins/logoutMixin.js
+++ b/src/mixins/logoutMixin.js
@@ -1,9 +1,12 @@
 export var logoutMixin = {
   methods: {
     logout: function() {
-      this.$store.commit("SET_USER_NAME", "HERMES Guest");
       this.$store.commit("SET_MID_LOGIN", false);
-      this.$store.commit("SET_WRITABLE_TOPICS", ["hermes.test"]);
+      this.$store.commit("SET_PROFILE", {
+        "email": "HERMES Guest",
+        "writable_topics": ["hermes.test"]
+      });
+
       location.reload();
     }
   }

--- a/src/mixins/logoutMixin.js
+++ b/src/mixins/logoutMixin.js
@@ -1,0 +1,10 @@
+export var logoutMixin = {
+  methods: {
+    logout: function() {
+      this.$store.commit("SET_USER_NAME", "HERMES Guest");
+      this.$store.commit("SET_MID_LOGIN", false);
+      this.$store.commit("SET_WRITABLE_TOPICS", ["hermes.test"]);
+      location.reload();
+    }
+  }
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import QueryMessages from "@/views/QueryMessages.vue"
 import ViewMessage from "@/views/ViewMessage.vue"
 import ViewNonlocalizedevent from "@/views/ViewNonlocalizedevent.vue"
 import AboutHermes from "@/views/AboutHermes.vue"
+import ProfileView from "@/views/Profile.vue"
 
 Vue.use(VueRouter)
 
@@ -34,6 +35,11 @@ const routes = [
     path: "/submit-message",
     name: "submit-message",
     component: SubmitMessage
+  },
+  {
+    path: "/profile",
+    name: "profile",
+    component: ProfileView
   },
   {
     path: "/about",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import createPersistedState from 'vuex-persistedstate';
+import axios from "axios";
 
 Vue.use(Vuex)
 
@@ -10,8 +11,11 @@ export default new Vuex.Store({
     extra_data: [],
     name: '',
     header: '',
-    username: 'HERMES Guest',
-    writable_topics: ['hermes.test'],
+    profile: {
+      'email': 'HERMES Guest',
+      'writable_topics': ['hermes.test']
+    },
+    hermesUrl: '',
     csrf_token: '',
     mid_login: false
   },
@@ -28,19 +32,21 @@ export default new Vuex.Store({
     getMainTableHeader(state) {
       return state.header;
     },
-    getUserName(state) {
-      return state.username;
+    getProfile(state) {
+      return state.profile;
     },
-    getWritableTopics(state) {
-      return state.writable_topics;
+    getHermesUrl(state) {
+      return state.hermesUrl;
     },
     getCsrfToken(state) {
       return state.csrf_token;
     },
     getMidLogin(state) {
       return state.mid_login;
+    },
+    isLoggedIn(state) {
+      return state.profile.email != 'HERMES Guest';
     }
-
   },
   plugins: [createPersistedState()],
   mutations: {
@@ -56,11 +62,11 @@ export default new Vuex.Store({
     SET_MAIN_TABLE_HEADER(state, header) {
       state.header = header;
     },
-    SET_USER_NAME(state, username) {
-      state.username = username;
+    SET_PROFILE(state, profile) {
+      state.profile = profile;
     },
-    SET_WRITABLE_TOPICS(state, writable_topics) {
-      state.writable_topics = writable_topics;
+    SET_HERMES_URL(state, url) {
+      state.hermesUrl = url;
     },
     SET_CSRF_TOKEN(state, csrf_token) {
       state.csrf_token = csrf_token;
@@ -70,6 +76,25 @@ export default new Vuex.Store({
     }
   },
   actions: {
+    getProfileData(context) {
+      return axios.get(context.state.hermesUrl + "api/v0/profile/", {
+          withCredentials: true,
+        })
+        .then((response) => {
+          context.commit("SET_PROFILE", response.data);
+          context.commit("SET_MID_LOGIN", false);
+        })
+        .catch((error) => {
+          console.log(error);
+          if (error.response.status == 401){
+            context.commit("SET_MID_LOGIN", false);
+            context.commit("SET_PROFILE", {
+              "email": "HERMES Guest",
+              "writable_topics": ["hermes.test"]
+            });
+          }
+        });
+    }
   },
   modules: {
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+import { getEnv } from "./env";
+
+export { getEnv };

--- a/src/views/AboutHermes.vue
+++ b/src/views/AboutHermes.vue
@@ -55,10 +55,10 @@
                                 HERMES message validation and submission can be accessed via API. The available endpoints are as follows:
                                 <b-list-group>
                                     <b-list-group-item>
-                                        <b>Validation:</b> <code>{{ baseUrl }}api/v0/submit_message/validate/</code>
+                                        <b>Validation:</b> <code>{{ this.getHermesUrl }}api/v0/submit_message/validate/</code>
                                     </b-list-group-item>
                                     <b-list-group-item>
-                                        <b>Submission:</b> <code>{{ baseUrl }}api/v0/submit_message/</code>
+                                        <b>Submission:</b> <code>{{ this.getHermesUrl }}api/v0/submit_message/</code>
                                     </b-list-group-item>
                                 </b-list-group>
                                 <b-card no-body class="mb-2">
@@ -180,7 +180,8 @@
 </template>
 
 <script>
-import getEnv from "@/utils/env.js";
+import { mapGetters } from "vuex";
+
 export default {
     data() {
         return {
@@ -300,9 +301,11 @@ export default {
                 { Field: 'group_associations', Description: 'String: Group associations for TNS.' },
                 { Field: 'spec_type', Description: 'String: Type of spectrum; Choices: [Object, Host, Synthetic, Sky, Arcs].' },
                 { Field: 'comments', Description: 'String: Free form section for comments about the observation.' },
-            ],
-            baseUrl: getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL")
+            ]
         }
+    },
+    computed: {
+        ...mapGetters(["getHermesUrl"])
     }
 }
 </script>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,0 +1,128 @@
+<template>
+  <b-container>
+    <b-alert :show="!isLoggedIn" variant="danger">
+      <p>You must login to access your profile</p>
+    </b-alert>
+    <b-alert dismissible variant="warning" v-model="showAlert" @dismissed="showAlert=false">{{ alertMessage }}</b-alert>
+    <b-row v-if="isLoggedIn">
+      <b-col md="4" class="border-right">
+        <h3 class="text-center">Writable Topics</h3>
+        <b-form-textarea v-model="writableTopics" readonly rows="8">
+        </b-form-textarea>
+        <p class="pt-3">To add more writable topics, attach your
+          <a class="text-secondary" href="https://my.hop.scimma.org/hopauth/">Scimma Auth</a> user account
+          to more groups with the topic permissions you want, or manually add write permissions to your existing Hermes hop credential.
+        </p>
+      </b-col>
+      <b-col md="4" class="border-right">
+        <h3 class="text-center">API Key</h3>
+        <p>
+          The following key may be used to authenticate when using the
+          <a class="text-secondary" :href="this.getHermesUrl + 'api/v0/'">Hermes API</a>. This key should be treated like a password.
+        </p>
+        <input class="form-control" :value="getProfile.api_token" onclick="this.select()" readonly />
+        <p class="pt-3">
+          If you think your API token may have been compromised (by accidentally checking it in to a public source code
+          repository, emailing it out, etc) you may revoke the token to obtain a new one using the button below.
+        </p>
+        <p>
+          <b>WARNING</b>: This will cause any applications that use this token to stop working!
+        </p>
+        <div class="text-center">
+          <b-button variant="danger" @click="performRevokeToken">
+            Revoke Token
+          </b-button>
+        </div>
+      </b-col>
+      <b-col md="4">
+        <h3 class="text-center">Hop Credential</h3>
+        <p>
+          The following Hop credential name was created and is used by Hermes for all authenication with Scimma Auth.
+        </p>
+        <input class="form-control" :value="getProfile.credential_name" onclick="this.select()" readonly />
+        <p class="pt-3">
+          If you believe this credential has been compromised, or is not working properly, you may destroy the credential
+          by clicking below. This will cause Hermes to regenerate a new Hop credential for your account. The initial permissions
+          on the credential are set using your Scimma Auth user accounts various group permissions.
+        </p>
+        <div class="text-center">
+          <b-button variant="danger" @click="performRevokeCredential">
+            Revoke Credential
+          </b-button>
+        </div>
+      </b-col>  
+    </b-row>
+  </b-container>
+</template>
+<script>
+
+import { mapGetters } from "vuex";
+import axios from "axios";
+import { logoutMixin } from '@/mixins/logoutMixin.js';
+
+export default {
+  name: 'ProfileView',
+  mixins: [logoutMixin],
+  data: function () {
+    return {
+      alertMessage: null,
+      showAlert: false
+    };
+  },
+  computed: {
+    ...mapGetters(["getProfile", "getCsrfToken", "isLoggedIn", "getHermesUrl"]),
+    writableTopics: function() {
+      return this.getProfile.writable_topics.join('\n');
+    }
+  },
+  methods: {
+    performRevokeToken: function (evt) {
+      evt.preventDefault();
+      axios({
+        method: 'post',
+        withCredentials: true,
+        // TODO: see if Vue.js can add the X-CSRFToken to all headers automagically
+        headers: {'Content-Type': 'application/json',
+                  'X-CSRFToken': this.getCsrfToken
+                  },
+        url: new URL('/api/v0/revoke_api_token/', this.getHermesUrl).href,
+      })
+      .then(() => {
+        this.$store.dispatch('getProfileData');
+        this.alertMessage = 'Token Successfully Revoked!';
+        this.showAlert = true;
+      })
+      .catch(error => {
+        console.log(error);
+        if (error.response.status == 401){
+          this.logout();
+        }
+      });
+    },
+    performRevokeCredential: function (evt) {
+      evt.preventDefault();
+      axios({
+        method: 'post',
+        withCredentials: true,
+        // TODO: see if Vue.js can add the X-CSRFToken to all headers automagically
+        headers: {'Content-Type': 'application/json',
+                  'X-CSRFToken': this.getCsrfToken
+                  },
+        url: new URL('/api/v0/revoke_hop_credential/', this.getHermesUrl).href,
+      })
+      .then(() => {
+        this.$store.dispatch('getProfileData');
+        this.alertMessage = 'Hop Credentials Successfully Revoked!';
+        this.showAlert = true;
+      })
+      .catch(error => {
+        console.log(error);
+        if (error.response.status == 401){
+          this.logout();
+        }
+      });
+    }
+  }
+};
+</script>
+  

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -11,7 +11,7 @@
         </b-form-textarea>
         <p class="pt-3">To add more writable topics, attach your
           <a class="text-secondary" href="https://my.hop.scimma.org/hopauth/">Scimma Auth</a> user account
-          to more groups with the topic permissions you want, or manually add write permissions to your existing Hermes hop credential.
+          to more groups with the topic permissions you want, or manually add write permissions to your existing Hermes SCiMMA Auth credential.
         </p>
       </b-col>
       <b-col md="4" class="border-right">
@@ -35,15 +35,15 @@
         </div>
       </b-col>
       <b-col md="4">
-        <h3 class="text-center">Hop Credential</h3>
+        <h3 class="text-center">SCiMMA Auth Credential</h3>
         <p>
-          The following Hop credential name was created and is used by Hermes for all authenication with Scimma Auth.
+          The following credential name was created and is used by Hermes for all authenication with SCiMMA Auth.
         </p>
         <input class="form-control" :value="getProfile.credential_name" onclick="this.select()" readonly />
         <p class="pt-3">
           If you believe this credential has been compromised, or is not working properly, you may destroy the credential
-          by clicking below. This will cause Hermes to regenerate a new Hop credential for your account. The initial permissions
-          on the credential are set using your Scimma Auth user accounts various group permissions.
+          by clicking below. This will cause Hermes to regenerate a new SCiMMA Auth credential for your account. The initial permissions
+          on the credential are set using your SCiMMA Auth user accounts various group permissions.
         </p>
         <div class="text-center">
           <b-button variant="danger" @click="performRevokeCredential">

--- a/src/views/QueryMessages.vue
+++ b/src/views/QueryMessages.vue
@@ -100,6 +100,7 @@
 </template>
 <script>
 import { OCSMixin } from 'ocs-component-lib';
+import { mapGetters } from "vuex";
 import getEnv from "@/utils/env.js";
 import axios from "axios";
 import dayjs from 'dayjs';
@@ -168,7 +169,7 @@ export default {
   mounted() {
     // Get available topics
     axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/topics/", {
+      .get(this.getHermesUrl + "api/v0/topics/", {
           withCredentials: true,
         })
       .then((response) => (this.topic_options = response.data.topics))
@@ -183,6 +184,7 @@ export default {
     dayjs.extend(relativeTime);
   },
   computed: {
+    ...mapGetters(["getHermesUrl"]),
     visibleFields() {
       return this.fields.filter(field => field.visible);
     }

--- a/src/views/ViewMessage.vue
+++ b/src/views/ViewMessage.vue
@@ -11,12 +11,14 @@ import getEnv from "@/utils/env.js";
 import axios from "axios";
 import '@/assets/css/view.css';
 import MessageDetail from '@/views/MessageDetail.vue';
+import { logoutMixin } from '@/mixins/logoutMixin.js';
 
 export default {
   name: "ViewMessage",
   components: {
     MessageDetail,
   },
+  mixins: [logoutMixin],
   data() {
     return {
       message: null,
@@ -38,9 +40,16 @@ export default {
   },
   created: function() {
     axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/messages/" + this.id + '/')
+      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/messages/" + this.id + '/', {
+          withCredentials: true,
+        })
       .then((response) => (this.message = response.data))
-      .catch(() => this.failedToLoad = true);
+      .catch((error) => {
+        this.failedToLoad = true;
+        if (error.response.status == 401){
+          this.logout();
+        }
+      });
   }
 };
 </script>

--- a/src/views/ViewMessage.vue
+++ b/src/views/ViewMessage.vue
@@ -7,11 +7,11 @@
   </div>
 </template>
 <script>
-import getEnv from "@/utils/env.js";
 import axios from "axios";
 import '@/assets/css/view.css';
 import MessageDetail from '@/views/MessageDetail.vue';
 import { logoutMixin } from '@/mixins/logoutMixin.js';
+import { mapGetters } from "vuex";
 
 export default {
   name: "ViewMessage",
@@ -26,6 +26,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters(["getHermesUrl"]),
     id: function() {
       return this.$route.params.id;
     },
@@ -40,7 +41,7 @@ export default {
   },
   created: function() {
     axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/messages/" + this.id + '/', {
+      .get(this.getHermesUrl + "api/v0/messages/" + this.id + '/', {
           withCredentials: true,
         })
       .then((response) => (this.message = response.data))

--- a/src/views/ViewNonlocalizedevent.vue
+++ b/src/views/ViewNonlocalizedevent.vue
@@ -1,86 +1,95 @@
 <template>
-    <div :class="containerSize">
-      <b-alert :show="failedToLoad" variant="danger">
-        <p>Nonlocalizedevent with ID {{ this.id }} not found.</p>
-      </b-alert>
-      <b-card v-if="nlevent">
-        <b-card-title class="text-center">
-          <b-link :href="getGraceDBLink(nlevent.event_id)" v-b-tooltip.hover
-            :title="getGraceDBLink(nlevent.event_id)"><b>{{ nlevent.event_id }}</b></b-link>
-        </b-card-title>
-        <hr>
-        <div v-if="nlevent.sequences.length > 0">
-          <h4 class="text-center">Sequences:</h4>
-          <div class="accordion" role="tablist" v-for="(sequence, idx) in nlevent.sequences" :key="'sequence-' + idx">
-            <b-card no-body class="mb-1">
-              <b-card-header header-tag="header" class="p-0" role="tab">
-                <b-button block v-b-toggle="'sequence-' + idx" variant="light">{{ getSequenceHeader(sequence) }}</b-button>
-              </b-card-header>
-              <b-collapse :id="'sequence-' + idx" accordion="sequence-accordion" role="tabpanel">
-                <message-detail :message="sequence.message" :id="'sequence-' + idx" class="mt-2"></message-detail>
-              </b-collapse>
-            </b-card>
-          </div>
+  <div :class="containerSize">
+    <b-alert :show="failedToLoad" variant="danger">
+      <p>Nonlocalizedevent with ID {{ this.id }} not found.</p>
+    </b-alert>
+    <b-card v-if="nlevent">
+      <b-card-title class="text-center">
+        <b-link :href="getGraceDBLink(nlevent.event_id)" v-b-tooltip.hover
+          :title="getGraceDBLink(nlevent.event_id)"><b>{{ nlevent.event_id }}</b></b-link>
+      </b-card-title>
+      <hr>
+      <div v-if="nlevent.sequences.length > 0">
+        <h4 class="text-center">Sequences:</h4>
+        <div class="accordion" role="tablist" v-for="(sequence, idx) in nlevent.sequences" :key="'sequence-' + idx">
+          <b-card no-body class="mb-1">
+            <b-card-header header-tag="header" class="p-0" role="tab">
+              <b-button block v-b-toggle="'sequence-' + idx" variant="light">{{ getSequenceHeader(sequence) }}</b-button>
+            </b-card-header>
+            <b-collapse :id="'sequence-' + idx" accordion="sequence-accordion" role="tabpanel">
+              <message-detail :message="sequence.message" :id="'sequence-' + idx" class="mt-2"></message-detail>
+            </b-collapse>
+          </b-card>
         </div>
-        <div v-if="nlevent.references.length > 0">
-          <h4 class="text-center">References:</h4>
-          <div class="accordion" role="tablist" v-for="(reference, idx) in nlevent.references" :key="'reference-' + idx">
-            <b-card no-body class="mb-1">
-              <b-card-header header-tag="header" class="p-0" role="tab">
-                <b-button block v-b-toggle="'reference-' + idx" variant="light">{{ reference.uuid }}</b-button>
-              </b-card-header>
-              <b-collapse :id="'reference-' + idx" accordion="reference-accordion" role="tabpanel">
-                <message-detail :message="reference" :id="'reference-' + idx" class="mt-2"></message-detail>
-              </b-collapse>
-            </b-card>
-          </div>
+      </div>
+      <div v-if="nlevent.references.length > 0">
+        <h4 class="text-center">References:</h4>
+        <div class="accordion" role="tablist" v-for="(reference, idx) in nlevent.references" :key="'reference-' + idx">
+          <b-card no-body class="mb-1">
+            <b-card-header header-tag="header" class="p-0" role="tab">
+              <b-button block v-b-toggle="'reference-' + idx" variant="light">{{ reference.uuid }}</b-button>
+            </b-card-header>
+            <b-collapse :id="'reference-' + idx" accordion="reference-accordion" role="tabpanel">
+              <message-detail :message="reference" :id="'reference-' + idx" class="mt-2"></message-detail>
+            </b-collapse>
+          </b-card>
         </div>
-      </b-card>
-    </div>
-  </template>
-  <script>
-  import getEnv from "@/utils/env.js";
-  import axios from "axios";
-  import '@/assets/css/view.css';
-  import MessageDetail from '@/views/MessageDetail.vue';
-  
-  export default {
-    name: "ViewNonlocalizedevent",
-    components: {
-        MessageDetail,
+      </div>
+    </b-card>
+  </div>
+</template>
+<script>
+import getEnv from "@/utils/env.js";
+import axios from "axios";
+import '@/assets/css/view.css';
+import MessageDetail from '@/views/MessageDetail.vue';
+import { logoutMixin } from '@/mixins/logoutMixin.js';
+
+export default {
+  name: "ViewNonlocalizedevent",
+  mixins: [logoutMixin],
+  components: {
+      MessageDetail,
+  },
+  data() {
+    return {
+      nlevent: null,
+      failedToLoad: false,
+    };
+  },
+  computed: {
+    id: function() {
+      return this.$route.params.id;
     },
-    data() {
-      return {
-        nlevent: null,
-        failedToLoad: false,
-      };
-    },
-    computed: {
-      id: function() {
-        return this.$route.params.id;
-      },
-      containerSize: function() {
-        if (this.failedToLoad) {
-          return 'w-99';
-        }
-        else {
-          return 'w-100';
-        }
+    containerSize: function() {
+      if (this.failedToLoad) {
+        return 'w-99';
       }
-    },
-    created: function() {
-      axios
-        .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/nonlocalizedevents/" + this.id + '/')
-        .then((response) => (this.nlevent = response.data))
-        .catch(() => this.failedToLoad = true);
-    },
-    methods: {
-      getSequenceHeader: function(sequence) {
-        return sequence.sequence_number + ': ' + sequence.sequence_type;
-      },
-      getGraceDBLink(superevent_id) {
-        return 'https://gracedb.ligo.org/superevents/' + superevent_id + '/view/';
-      },
+      else {
+        return 'w-100';
+      }
     }
-  };
-  </script>
+  },
+  created: function() {
+    axios
+      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/nonlocalizedevents/" + this.id + '/', {
+        withCredentials: true,
+      })
+      .then((response) => (this.nlevent = response.data))
+      .catch((error) => {
+        this.failedToLoad = true;
+        if (error.response.status == 401){
+          this.logout();
+        }
+      });
+  },
+  methods: {
+    getSequenceHeader: function(sequence) {
+      return sequence.sequence_number + ': ' + sequence.sequence_type;
+    },
+    getGraceDBLink(superevent_id) {
+      return 'https://gracedb.ligo.org/superevents/' + superevent_id + '/view/';
+    },
+  }
+};
+</script>

--- a/src/views/ViewNonlocalizedevent.vue
+++ b/src/views/ViewNonlocalizedevent.vue
@@ -39,11 +39,11 @@
   </div>
 </template>
 <script>
-import getEnv from "@/utils/env.js";
 import axios from "axios";
 import '@/assets/css/view.css';
 import MessageDetail from '@/views/MessageDetail.vue';
 import { logoutMixin } from '@/mixins/logoutMixin.js';
+import { mapGetters } from "vuex";
 
 export default {
   name: "ViewNonlocalizedevent",
@@ -58,6 +58,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters(["getHermesUrl"]),
     id: function() {
       return this.$route.params.id;
     },
@@ -72,7 +73,7 @@ export default {
   },
   created: function() {
     axios
-      .get(getEnv("VUE_APP_HERMES_BACKEND_ROOT_URL") + "api/v0/nonlocalizedevents/" + this.id + '/', {
+      .get(this.getHermesUrl + "api/v0/nonlocalizedevents/" + this.id + '/', {
         withCredentials: true,
       })
       .then((response) => (this.nlevent = response.data))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
+    "noImplicitAny": false,
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "skipLibCheck": true,


### PR DESCRIPTION
…refreshed or logged out, and setup all calls to catch a 401 and trigger UI logout

This goes along with the hermes PR. The behavior now is that if your oidc credentials expire, the next api call that recieves the 401 back will trigger your UI to visibly logout (say Hermes-Guest again), and reload the page you are on. I think this is the safest thing to do if a user has their oidc creds expire, and then they can login again if they want. Since we are setting the timeout to a long time (2 weeks), this shouldn't happen often. 