### PR TITLE
change universal link color to be more visible

### DIFF
--- a/src/assets/css/view.css
+++ b/src/assets/css/view.css
@@ -43,3 +43,7 @@
     padding-right: 16px;
     padding-left: 0px;
 }
+
+a {
+    color: #1c7aa3;
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/32683393/234073405-39b9ac27-d418-48ea-82e5-ecbface5940d.png)
vs
![image](https://user-images.githubusercontent.com/32683393/234073273-b988808f-1ecc-4de3-8f79-077e21d54155.png)

I'm open to other color suggestions.