### PR TITLE
Add vue-multiselect package and use it for multiselect widget for top…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "vue": "^2.6.14",
         "vue-axios": "^3.4.1",
         "vue-class-component": "^7.2.3",
+        "vue-multiselect": "^2.1.7",
+        "vue-multiselect-bootstrap-theme": "^1.0.7",
         "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.5.1",
         "vuetify": "^2.6.10",
@@ -12156,6 +12158,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/vue-multiselect": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.7.tgz",
+      "integrity": "sha512-KIegcN+Ntwg3cbkY/jhw2s/+XJUM0Lpi/LcKFYCS8PrZHcWBl2iKCVze7ZCnRj3w8H7/lUJ9v7rj9KQiNxApBw==",
+      "engines": {
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/vue-multiselect-bootstrap-theme": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vue-multiselect-bootstrap-theme/-/vue-multiselect-bootstrap-theme-1.0.7.tgz",
+      "integrity": "sha512-0+GWbOr5IiHRBD6w2iwULP1rFv10Yexao3auq7vSh3ZUqf4JmS2LFkb9qOvvs0te2w/FwOEbdwf3xech7BXgVw==",
+      "peerDependencies": {
+        "bootstrap": ">=3.x.x"
+      }
+    },
     "node_modules/vue-property-decorator": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz",
@@ -21945,6 +21964,17 @@
           }
         }
       }
+    },
+    "vue-multiselect": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.7.tgz",
+      "integrity": "sha512-KIegcN+Ntwg3cbkY/jhw2s/+XJUM0Lpi/LcKFYCS8PrZHcWBl2iKCVze7ZCnRj3w8H7/lUJ9v7rj9KQiNxApBw=="
+    },
+    "vue-multiselect-bootstrap-theme": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vue-multiselect-bootstrap-theme/-/vue-multiselect-bootstrap-theme-1.0.7.tgz",
+      "integrity": "sha512-0+GWbOr5IiHRBD6w2iwULP1rFv10Yexao3auq7vSh3ZUqf4JmS2LFkb9qOvvs0te2w/FwOEbdwf3xech7BXgVw==",
+      "requires": {}
     },
     "vue-property-decorator": {
       "version": "9.1.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "vue": "^2.6.14",
     "vue-axios": "^3.4.1",
     "vue-class-component": "^7.2.3",
+    "vue-multiselect": "^2.1.7",
+    "vue-multiselect-bootstrap-theme": "^1.0.7",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.5.1",
     "vuetify": "^2.6.10",
@@ -84,6 +86,7 @@
       "parser": "@typescript-eslint/parser"
     },
     "rules": {
+      "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
       "vue/no-unused-vars": "off",
       "vue/no-mutating-props": "off",
       "@typescript-eslint/no-unused-vars": "off"

--- a/src/views/QueryMessages.vue
+++ b/src/views/QueryMessages.vue
@@ -3,18 +3,16 @@
   <b-row>
     <b-col md="7">
       <b-row class="pb-2">
-        <b-col class="col-md-4">
-          <!-- Topic Filter -->
-          <b-form-select
-            id="topic_selector"
-            v-model.lazy="queryParams.topic_exact"
+        <b-col class="col-md-6">
+          <multiselect
+            v-model.lazy="queryParams.topic"
+            placeholder="Filter by Topic"
+            :optionHeight=38
             :options="topic_options"
-            @change="onTopicChange"
+            :multiple="true"
+            @input="onTopicChange"
           >
-            <template #first>
-              <b-form-select-option value="">-- All Topics --</b-form-select-option>
-            </template>
-          </b-form-select>
+          </multiselect>
         </b-col>
         <b-col class="col-md-6 ml-auto">
           <b-form-input type="search" placeholder="Search Terms" v-model.lazy="queryParams.search" @input="searchTerms"></b-form-input>
@@ -93,6 +91,9 @@
 </template>
 <script>
 import _ from 'lodash';
+import Multiselect from 'vue-multiselect';
+import "vue-multiselect/dist/vue-multiselect.min.css";
+import "vue-multiselect-bootstrap-theme/dist/vue-multiselect-bootstrap4.scss";
 import { OCSMixin } from 'ocs-component-lib';
 import { mapGetters } from "vuex";
 import getEnv from "@/utils/env.js";
@@ -108,6 +109,7 @@ export default {
   mixins: [OCSMixin.paginationAndFilteringMixin, logoutMixin],
   components: {
     MessageDetail,
+    Multiselect
   },
   data() {
     return {
@@ -191,7 +193,7 @@ export default {
     // Overrides method in paginationAndFilteringMixin
     initializeDefaultQueryParams: function() {
       const defaultQueryParams = {
-        topic_exact: '',
+        topic: [],
         search: '',
         limit: 10,
         offset: 0
@@ -207,7 +209,7 @@ export default {
     onTopicChange(value) {
       this.fields.forEach(field => {
         if (field.key == 'topic') {
-          field.visible = (value == '');
+          field.visible = (value == []);
         }
       });
       let fakeEvent = {'preventDefault': () => true};


### PR DESCRIPTION
…ic selection

The vue-multiselect widget offers a searchable topic list, so I think it should fulfill our needs without needing any profile stuff. You can type to search, then click to filter by that, and it adds a tag for the filtered topics in the bar. You can click the "x" on them to remove the tag, or remove them by clicking again within the select box on that option. Screenshot below showing what it looks like with two topics selected.

![image](https://user-images.githubusercontent.com/11946945/235847620-0f497967-2383-4603-b3d6-282a14ccdc4e.png)
