### PR TITLE
Fix/ingress v1.22

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "stable"
 description: Helm Chart for the HERMES frontend
 name: hermes-frontend
-version: 0.1.0
+version: 0.2.0

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,13 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hermes-frontend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-  {{- else -}}
-apiVersion: extensions/v1beta1
-  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -37,15 +31,10 @@ spec:
         - path: {{ . }}
           pathType: Prefix
           backend:
-        {{- if semverCompare ">=1.22-0" $.Capabilities.KubeVersion.GitVersion }}
             service:
               name: {{ $fullName }}
               port:
                 number: {{ $svcPort }}
-        {{- else}}
-            serviceName: {{ $fullName }}
-            servicePort: {{ $svcPort }}
-        {{- end }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
This updates the ingress spec for the calibration-tom to use networking.k8s.io/v1 which is compliant with k8s v1.22

I verified the correctness via:

```
helm template helm-chart -f helm-chart/values-prod.yaml | kubeval --kubernetes-version 1.22.1 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
PASS - hermes-frontend/templates/serviceaccount.yaml contains a valid ServiceAccount (RELEASE-NAME-hermes-frontend)
PASS - hermes-frontend/templates/configmap.yaml contains a valid ConfigMap (RELEASE-NAME-hermes-frontend)
PASS - hermes-frontend/templates/service.yaml contains a valid Service (RELEASE-NAME-hermes-frontend)
PASS - hermes-frontend/templates/deployment.yaml contains a valid Deployment (RELEASE-NAME-hermes-frontend)
PASS - hermes-frontend/templates/ingress.yaml contains a valid Ingress (RELEASE-NAME-hermes-frontend)
PASS - hermes-frontend/templates/tests/test-connection.yaml contains a valid Pod (RELEASE-NAME-hermes-frontend-test-connection)
```

I'll let y'all sort out which branches this needs to be on - but it should apply to all deployments. So dev and prod?