### PR TITLE
UI for uploading files for TNS submissionlin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "core-js": "^3.8.3",
         "dayjs": "^1.11.7",
         "dotenv": "^16.0.0",
+        "filesize": "^10.0.11",
         "http": "^0.0.1-security",
         "http-browserify": "^1.7.0",
         "https": "^1.0.0",
@@ -6621,6 +6622,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.11.tgz",
+      "integrity": "sha512-gbHLdV7L2tTbJ8tUXjtfngakN6k+F6EQhxMxK5yfhwvy0XuyyXfFwG54130otkTZxU16pFRnPpPVn0gxxQ8HTQ==",
+      "engines": {
+        "node": ">= 10.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -17916,6 +17925,11 @@
           }
         }
       }
+    },
+    "filesize": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.11.tgz",
+      "integrity": "sha512-gbHLdV7L2tTbJ8tUXjtfngakN6k+F6EQhxMxK5yfhwvy0XuyyXfFwG54130otkTZxU16pFRnPpPVn0gxxQ8HTQ=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "core-js": "^3.8.3",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.0",
+    "filesize": "^10.0.11",
     "http": "^0.0.1-security",
     "http-browserify": "^1.7.0",
     "https": "^1.0.0",

--- a/src/components/message-composition/DataSection.vue
+++ b/src/components/message-composition/DataSection.vue
@@ -64,6 +64,10 @@ export default {
       type: String,
       required: true
     },
+    pluralDatatype: {
+      type: String,
+      required: false
+    },
     isEmpty: {
       type: Boolean,
       default: false
@@ -95,7 +99,6 @@ export default {
       visible: false,
       id: this.section,
       tabName: this.section.toLowerCase() + '-tab',
-      capitalSection: _.capitalize(this.section),
       fileInput: null,
     }
   },
@@ -106,6 +109,12 @@ export default {
     }
   },
   computed: {
+    capitalSection: function() {
+      if (this.pluralDatatype){
+        return this.pluralDatatype;
+      }
+      return _.capitalize(this.section);
+    },
     hasErrors: function() {
       return !_.isEmpty(this.errors);
     },

--- a/src/components/message-composition/HermesMessage.vue
+++ b/src/components/message-composition/HermesMessage.vue
@@ -276,6 +276,7 @@
           <data-section
             section="extra_data"
             datatype="Extra Data"
+            plural-datatype="Extra Data"
             :errors="getErrors('data.extra_data', [])"
             :sectionShowSimple="this.sectionShowSimple['extra_data']"
             :onlySimple=true
@@ -354,6 +355,35 @@
                 </ul>
               </b-tab>
             </b-tabs>
+          </data-section>
+          <data-section
+            v-if="hermesMessage.submit_to_tns"
+            section="file_upload"
+            datatype="Files"
+            plural-datatype="Files"
+            :errors="[]"
+            :sectionShowSimple="this.sectionShowSimple['extra_data']"
+            :onlySimple=true
+            :disabled=true
+            :isEmpty="hermesMessage.files.length == 0"
+            ref="file_uploadSection"
+          >
+            <div>
+              <b-row>
+                <b-col md="11">
+                  <b-form-file class="mb-2" v-model="hermesMessage.files" multiple placeholder="Choose a file or drop it here..." drop-placeholder="Drop file here...">
+                  </b-form-file>
+                </b-col>
+                <b-col md="1">
+                  <b-button title="Clear all files" @click="hermesMessage.files = [];"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
+                </b-col>
+              </b-row>
+              <b-list-group v-for="(file, index) in hermesMessage.files" :key="'file' + index" flush>
+                <b-list-group-item><b>{{ file.name }}</b>:  {{ file.size }} bytes
+                  <b-button title="Remove this file" @click="removeFile(index)"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
+                </b-list-group-item>
+              </b-list-group>
+            </div>
           </data-section>
         </b-tab>
         <b-tab>
@@ -864,6 +894,9 @@
           this.sectionShowSimple['targets'] = false;
           this.sectionShowSimple['photometry'] = false;
         }
+        else {
+          this.hermesMessage.files = [];
+        }
       }
     },
     methods: {
@@ -898,6 +931,11 @@
           this.$refs[section + 'Section'].forceVisibility(false);
         }
         this.update();
+      },
+      removeFile: function(idx) {
+        if (idx < this.hermesMessage.files.length) {
+          this.hermesMessage.files.splice(idx, 1);
+        }
       },
       generatePlainText: function() {
         this.$emit('generate-plain-text');

--- a/src/components/message-composition/HermesMessage.vue
+++ b/src/components/message-composition/HermesMessage.vue
@@ -371,16 +371,29 @@
             <div>
               <b-row>
                 <b-col md="11">
-                  <b-form-file class="mb-2" v-model="hermesMessage.files" multiple placeholder="Choose a file or drop it here..." drop-placeholder="Drop file here...">
+                  <b-form-file class="mb-2" v-model="hermesMessage.files" multiple placeholder="Choose a file or drop it here..." drop-placeholder="Drop file here..." @input="appendFileComments">
                   </b-form-file>
                 </b-col>
                 <b-col md="1">
-                  <b-button title="Clear all files" @click="hermesMessage.files = [];"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
+                  <b-button title="Clear all files" @click="hermesMessage.files = []; hermesMessage.file_comments = [];"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
                 </b-col>
               </b-row>
               <b-list-group v-for="(file, index) in hermesMessage.files" :key="'file' + index" flush>
-                <b-list-group-item><b>{{ file.name }}</b>:  {{ file.size }} bytes
-                  <b-button title="Remove this file" @click="removeFile(index)"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
+                <b-list-group-item class="pr-0">
+                  <b-row>
+                    <b-col md="3" align-self="center" class="pr-2">
+                      <b>{{ file.name }}</b>
+                    </b-col>
+                    <b-col md="1" align-self="center" class="pl-2 pr-0">
+                      {{ getFileSize(file.size) }}
+                    </b-col>
+                    <b-col md="7">
+                      <b-form-input v-model="hermesMessage.file_comments[index]" placeholder="Comments"></b-form-input>
+                    </b-col>
+                    <b-col md="1">
+                      <b-button title="Remove this file" @click="removeFile(index)"><b-icon icon="trash" aria-hidden="true"></b-icon></b-button>
+                    </b-col>
+                  </b-row>
                 </b-list-group-item>
               </b-list-group>
             </div>
@@ -426,6 +439,7 @@
   <script>
   import _ from 'lodash';
   import { mapGetters } from "vuex";
+  import {filesize} from "filesize";
   import '@/assets/css/submissions.css';
   import DataSection from '@/components/message-composition/DataSection.vue'
   import DataReference from '@/components/message-composition/DataReference.vue'
@@ -896,6 +910,7 @@
         }
         else {
           this.hermesMessage.files = [];
+          this.hermesMessage.file_comments = [];
         }
       }
     },
@@ -935,7 +950,19 @@
       removeFile: function(idx) {
         if (idx < this.hermesMessage.files.length) {
           this.hermesMessage.files.splice(idx, 1);
+          this.hermesMessage.file_comments.splice(idx, 1);
         }
+      },
+      appendFileComments: function() {
+        // If we change files, we should just clear all comments to be safe
+        this.hermesMessage.file_comments = [];
+        // Then add an empty comment for each file that exists
+        while (this.hermesMessage.file_comments.length < this.hermesMessage.files.length) {
+          this.hermesMessage.file_comments.push('');
+        }
+      },
+      getFileSize: function(size) {
+        return filesize(size, {standard: 'jedec'})
       },
       generatePlainText: function() {
         this.$emit('generate-plain-text');

--- a/src/components/message-composition/MessageCompositionForm.vue
+++ b/src/components/message-composition/MessageCompositionForm.vue
@@ -56,6 +56,7 @@ export default {
       type: Object,
       default: () => {
         return {
+          files: [],
           title: '',
           authors: '',
           topic: '',
@@ -165,17 +166,26 @@ export default {
       });
     },
     submitToHop() {
-      let payload = this.sanitizedMessageData();
+      let payload = JSON.stringify(this.sanitizedMessageData());
+      let formData = null;
+      if (this.hermesMessage.files.length > 0){
+        formData = new FormData();
+        this.hermesMessage.files.forEach(function (file) {
+          // formData.append("file" + index, file);
+          formData.append("files", file);
+        });
+        formData.append("data", payload);
+      }
       // Post message via axios
       axios({
         method: 'post',
         withCredentials: true,
         // TODO: see if Vue.js can add the X-CSRFToken to all headers automagically
-        headers: {'Content-Type': 'application/json',
+        headers: {'Content-Type': _.isNull(formData) ? 'application/json' : 'multipart/form-data',
                   'X-CSRFToken': this.getCsrfToken
                   },
         url: new URL('/api/v0/' + this.submissionEndpoint + '/', this.getHermesUrl).href,
-        data: JSON.stringify(payload)
+        data: _.isNull(formData) ? payload : formData
       })
       .then(() => {
         // log response, redirect to homepage
@@ -193,6 +203,7 @@ export default {
     },
     clearForm() {
       // Reset the page to a clean state
+      this.hermesMessage.files = [];
       this.hermesMessage.title = '';
       this.hermesMessage.authors = '';
       this.hermesMessage.topic = this.topicOptions[0];

--- a/src/components/message-composition/MessageCompositionForm.vue
+++ b/src/components/message-composition/MessageCompositionForm.vue
@@ -57,6 +57,7 @@ export default {
       default: () => {
         return {
           files: [],
+          file_comments: [],
           title: '',
           authors: '',
           topic: '',
@@ -204,6 +205,7 @@ export default {
     clearForm() {
       // Reset the page to a clean state
       this.hermesMessage.files = [];
+      this.hermesMessage.file_comments = [];
       this.hermesMessage.title = '';
       this.hermesMessage.authors = '';
       this.hermesMessage.topic = this.topicOptions[0];

--- a/src/mixins/messageFormatMixin.js
+++ b/src/mixins/messageFormatMixin.js
@@ -73,6 +73,9 @@ export var messageFormatMixin = {
       if (_.isEmpty(cleanMessage.data.event_id)) {
         delete cleanMessage.data.event_id;
       }
+      if (_.isEmpty(cleanMessage.file_comments)) {
+        delete cleanMessage.file_comments;
+      }
       cleanMessage.data.references = this.sanitizeMessageSection(cleanMessage.data.references);
       cleanMessage.data.targets = this.sanitizeMessageSection(cleanMessage.data.targets);
       cleanMessage.data.photometry = this.sanitizeMessageSection(cleanMessage.data.photometry);

--- a/src/mixins/messageFormatMixin.js
+++ b/src/mixins/messageFormatMixin.js
@@ -69,6 +69,7 @@ export var messageFormatMixin = {
     },
     sanitizedMessageData: function() {
       let cleanMessage = _.cloneDeep(this.hermesMessage);
+      delete cleanMessage.files;
       if (_.isEmpty(cleanMessage.data.event_id)) {
         delete cleanMessage.data.event_id;
       }

--- a/src/views/AboutHermes.vue
+++ b/src/views/AboutHermes.vue
@@ -121,7 +121,7 @@ response = requests.post(url=hermes_submit_url, json=message, headers=headers)
                                             <li>Create a header for your submission including the API token from your <a :href="baseUrl + 'profile'">profile</a>.</li>
                                             <li>Build a message dictionary. TNS submission requires certain fields, including title, authors, at least one target with group and discovery information, and at least one photometry datapoint and one limiting brightness.</li>
                                             <li>Certain fields are required to use one of the available <a href="https://www.wis-tns.org/api/values">TNS options values</a> when submitting to TNS.</li>
-                                            <li>Files can also be uploaded as part of the TNS submission. They will reside on the TNS and can be downloaded from the TNS object page.</li>
+                                            <li>Files can also be uploaded as part of the TNS submission. They will reside on the TNS and can be downloaded from the TNS object page. A list of `file_comments` can be added to the message payload to associate with the files.</li>
                                             <li>The TNS object ID and a link to it's page will be added to the hermes message on submission</li>
                                             <br>
                                             <P>Note: During development, you can use the validation endpoint above to check that your message passes validation without submitting to the stream. The validation endpoint expects only json data, as specified in the <b-link @click="activeTab1()">Build a Basic API Post</b-link> section</P>
@@ -176,6 +176,7 @@ message = {
         }]
     }
     'message_text': 'Sample Message',
+    'file_comments': ['This is my spectrum data', 'This is my finder chart image'] # Optional
 }
 
 # JSON encode message so it can be sent with files as part of multipart/form-data


### PR DESCRIPTION
Here is the UI portion of tns file uploading. It adds another section "Files" to upload/show files when submit_to_tns is selected. It looks like this:
![image](https://github.com/LCOGT/hermes-frontend/assets/11946945/8981afab-00e1-4c62-b397-4c99739b7e4b)

I also added info on how to structure an API request with files for TNS submission to the about page. It looks like this:
![image](https://github.com/LCOGT/hermes-frontend/assets/11946945/6eae8d1e-284a-433e-818e-46079a83bc4e)
This is because the structure of your post must be slightly different for a multipart/form-data - basically you have to json encode the data dict into a string and send it in the 'data' key next to the files sent in the 'files' key, and then we put it back into json on the server in the parser. 