### PR TITLE
Add in new archival fields and refactor tns options a bit

### DIFF
--- a/src/components/message-composition/DataPhotometry.vue
+++ b/src/components/message-composition/DataPhotometry.vue
@@ -78,7 +78,7 @@
               field="bandpass"
               label="Band:"
               :hide=false
-              :options="getTnsValuesList('filters')"
+              :options="getTnsValuesList('filters', true)"
               :errors="errors.bandpass"
               @input="update"
             />
@@ -107,7 +107,7 @@
               field="telescope"
               label="Telescope:"
               :hide=false
-              :options="getTnsValuesList('telescopes')"
+              :options="getTnsValuesList('telescopes', true)"
               :errors="errors.telescope"
               @input="update"
             />
@@ -121,7 +121,7 @@
               field="instrument"
               label="Instrument:"
               :hide=false
-              :options="getTnsValuesList('instruments')"
+              :options="getTnsValuesList('instruments', true)"
               :errors="errors.instrument"
               @input="update"
             />
@@ -175,12 +175,12 @@
   <script>
   import { OCSMixin } from 'ocs-component-lib';
   import _ from 'lodash';
-  import { mapGetters } from "vuex";
-  import {schemaDataMixin} from '@/mixins/schemaDataMixin.js';
+  import { schemaDataMixin } from '@/mixins/schemaDataMixin.js';
+  import { tnsUtilsMixin } from '@/mixins/tnsUtilsMixin.js';
 
   export default {
     name: 'DataPhotometry',
-    mixins: [OCSMixin.confirmMixin, schemaDataMixin],
+    mixins: [OCSMixin.confirmMixin, schemaDataMixin, tnsUtilsMixin],
     props: {
       index: {
         type: Number,
@@ -215,20 +215,8 @@
       };
     },
     computed: {
-      ...mapGetters(["getTnsOptions"]),
       targetNames: function() {
         return _.map(this.targets, 'name');
-      }
-    },
-    methods: {
-      getTnsValuesList: function(category) {
-        let tnsOptions = this.getTnsOptions;
-        if (_.isArray(tnsOptions[category])) {
-          return tnsOptions[category].sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
-        }
-        else {
-          return _.values(tnsOptions[category]).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
-        }
       }
     }
   };

--- a/src/components/message-composition/DataSpectroscopy.vue
+++ b/src/components/message-composition/DataSpectroscopy.vue
@@ -162,7 +162,7 @@
               field="telescope"
               label="Telescope:"
               :hide=false
-              :options="getTnsValuesList('telescopes')"
+              :options="getTnsValuesList('telescopes', true)"
               :errors="errors.telescope"
               @input="update"
             />
@@ -176,7 +176,7 @@
               field="instrument"
               label="Instrument:"
               :hide=false
-              :options="getTnsValuesList('instruments')"
+              :options="getTnsValuesList('instruments', true)"
               :errors="errors.instrument"
               @input="update"
             />
@@ -200,7 +200,7 @@
                   desc="Classification of spectroscopic datum"
                   :hide=false
                   :errors="errors.classification"
-                  :options="getTnsValuesList('object_types')"
+                  :options="getTnsValuesList('object_types', true)"
                   @input="update"
               />
             </b-col>
@@ -222,7 +222,7 @@
                   desc="Type of the Spectrograph"
                   :hide=false
                   :errors="errors.spec_type"
-                  :options="getTnsValuesList('spectra_types')"
+                  :options="getTnsValuesList('spectra_types', true)"
                   @input="update"
               />
             </b-col>
@@ -259,10 +259,10 @@
   </template>
   <script>
   import { OCSMixin } from 'ocs-component-lib';
-  import { mapGetters } from "vuex";
   import _ from 'lodash';
   import '@/assets/css/view.css';
-  import {schemaDataMixin} from '@/mixins/schemaDataMixin.js';
+  import { schemaDataMixin } from '@/mixins/schemaDataMixin.js';
+  import { tnsUtilsMixin } from '@/mixins/tnsUtilsMixin.js';
   import FilesWithDescriptions from '@/components/message-composition/FilesWithDescriptions.vue'
   import ShowWrapper from '@/components/message-composition/ShowWrapper.vue'
 
@@ -272,7 +272,7 @@
       ShowWrapper,
       FilesWithDescriptions
     },
-    mixins: [OCSMixin.confirmMixin, schemaDataMixin],
+    mixins: [OCSMixin.confirmMixin, schemaDataMixin, tnsUtilsMixin],
     props: {
       index: {
         type: Number,
@@ -311,7 +311,6 @@
       };
     },
     computed: {
-      ...mapGetters(["getTnsOptions"]),
       targetNames: function() {
         return _.map(this.targets, 'name');
       },
@@ -446,11 +445,7 @@
           this.spectroscopy.wavelength.push(null);
           this.update();
         }
-      },
-      getTnsValuesList: function(category) {
-        let tnsOptions = this.getTnsOptions;
-        return _.values(tnsOptions[category]).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
-      },
+      }
     }
   };
   </script>

--- a/src/components/message-composition/DataTarget.vue
+++ b/src/components/message-composition/DataTarget.vue
@@ -215,7 +215,7 @@
                 placeholder="Associate TNS Groups:"
                 :maxHeight=500
                 :optionHeight=38
-                :options="getTnsGroups()"
+                :options="getTnsValuesList('groups')"
                 :multiple="true"
                 @input="update"
               >
@@ -281,14 +281,14 @@
   </template>
   <script>
   import _ from 'lodash';
-  import { mapGetters } from "vuex";
   import '@/assets/css/submissions.css';
   import Multiselect from 'vue-multiselect';
   import "vue-multiselect/dist/vue-multiselect.min.css";
   import "vue-multiselect-bootstrap-theme/dist/vue-multiselect-bootstrap4.scss";
   import { OCSMixin } from 'ocs-component-lib';
   import DiscoveryInfo from '@/components/message-composition/DiscoveryInfo.vue'
-  import {schemaDataMixin} from '@/mixins/schemaDataMixin.js';
+  import { schemaDataMixin } from '@/mixins/schemaDataMixin.js';
+  import { tnsUtilsMixin } from '@/mixins/tnsUtilsMixin.js';
   import FilesWithDescriptions from '@/components/message-composition/FilesWithDescriptions.vue'
 
   export default {
@@ -298,7 +298,7 @@
       Multiselect,
       FilesWithDescriptions
     },
-    mixins: [OCSMixin.confirmMixin, schemaDataMixin],
+    mixins: [OCSMixin.confirmMixin, schemaDataMixin, tnsUtilsMixin],
     props: {
       index: {
         type: Number,
@@ -351,7 +351,6 @@
       }
     },
     computed: {
-      ...mapGetters(["getTnsOptions"]),
       collapseVisible: {
         get: function() {
           return !this.advancedOptionsCollapsed;
@@ -409,10 +408,6 @@
           this.target.pm_dec = null;
         }
         this.update();
-      },
-      getTnsGroups: function() {
-        let tnsOptions = this.getTnsOptions;
-        return _.values(tnsOptions['groups']).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
       }
     }
   };

--- a/src/components/message-composition/DiscoveryInfo.vue
+++ b/src/components/message-composition/DiscoveryInfo.vue
@@ -17,7 +17,7 @@
               field="reporting_group"
               label="Reporting Group:"
               :hide=false
-              :options="getTnsGroups()"
+              :options="getTnsValuesList('groups', true)"
               :errors="errors.reporting_group"
               @input="update"
           />
@@ -31,7 +31,7 @@
               field="discovery_source"
               label="Source:"
               :hide=false
-              :options="getTnsGroups()"
+              :options="getTnsValuesList('groups', true)"
               :errors="errors.discovery_source"
               @input="update"
           />
@@ -60,15 +60,35 @@
           </ocs-custom-field>
         </b-col>
       </b-form-row>
+      <b-form-row>
+            <b-col md="4">
+              <ocs-custom-field v-if="!isTns" v-model="data.nondetection_source" field="nondetection_source" label="Nondetection Source:" :hide=false
+                :errors="errors.nondetection_source" @input="update" />
+              <ocs-custom-select
+                  v-else
+                  v-model="data.nondetection_source"
+                  field="nondetection_source"
+                  label="Nondetection Source:"
+                  :hide=false
+                  :options="getTnsValuesList('archives', true)"
+                  :errors="errors.nondetection_source"
+                  @input="update"
+              />
+            </b-col>
+            <b-col md="8">
+              <ocs-custom-field v-model="data.nondetection_comments" field="nondetection_comments" label="Nondetection Comments:" :hide=false
+                :errors="errors.nondetection_comments" @input="update" />
+            </b-col>
+          </b-form-row>
     </b-card-body>
   </b-card>
 </template>
 <script>
-  import _ from 'lodash';
-  import { mapGetters } from "vuex";
+  import { tnsUtilsMixin } from '@/mixins/tnsUtilsMixin.js';
 
   export default {
     name: 'DiscoveryInfo',
+    mixins: [tnsUtilsMixin],
     props: {
       index: {
         type: Number,
@@ -89,22 +109,15 @@
     },
     data: function() {
       return {
-        transientTypes: ['AGN', 'FRB', 'NUC', 'Other', 'PNV', 'PSN'],
+        transientTypes: [{value: null, text: ''}, 'AGN', 'FRB', 'NUC', 'Other', 'PNV', 'PSN'],
         proprietaryPeriodUnits: ['Days', 'Months', 'Years'],
         show: true,
         id: 'discovery-info-' + this.index
       };
     },
-    computed: {
-      ...mapGetters(["getTnsOptions"])
-    },
     methods: {
       update: function () {
         this.$emit('message-updated');
-      },
-      getTnsGroups: function() {
-        let tnsOptions = this.getTnsOptions;
-        return _.values(tnsOptions['groups']).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
       }
     }
   };

--- a/src/components/message-composition/HermesMessage.vue
+++ b/src/components/message-composition/HermesMessage.vue
@@ -582,7 +582,9 @@
               'discovery_source': null,
               'transient_type': null,
               'proprietary_period': null,
-              'proprietary_period_units': null
+              'proprietary_period_units': null,
+              'nondetection_source': null,
+              'nondetection_comments': null,
             },
             'ra': null,
             'dec': null,

--- a/src/mixins/tnsUtilsMixin.js
+++ b/src/mixins/tnsUtilsMixin.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+import { mapGetters } from "vuex";
+
+export var tnsUtilsMixin = {
+  computed: {
+    ...mapGetters(["getTnsOptions"]),
+  },
+  methods: {
+    getTnsValuesList: function(category, addNull = false) {
+      let tnsOptions = this.getTnsOptions;
+      let outputArray = []
+      if (addNull) {
+          outputArray.push({value: null, text: ''})
+      }
+      if (_.isArray(tnsOptions[category])) {
+          return outputArray.concat(tnsOptions[category].sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'})));
+      }
+      else {
+          return outputArray.concat(_.values(tnsOptions[category]).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'})));
+      }
+    }
+  }
+};

--- a/src/views/AboutHermes.vue
+++ b/src/views/AboutHermes.vue
@@ -716,6 +716,8 @@ export default {
                 { Field: 'transient_type', Description: 'String: Type of transient; Accepted values are [PSN, nuc, PNV, AGN, Other].' },
                 { Field: 'proprietary_period', Description: 'Float: Length of time discovery should remain proprietary on TNS.' },
                 { Field: 'proprietary_period_unit', Description: 'Sring: Units for proprietary period; [Days, Months, Years].' },
+                { Field: 'nondetection_source', Description: 'String: Source catalog for the last nondetection on this target. Used in TNS reports.' },
+                { Field: 'nondetection_comments', Description: 'String: Comments on the last nondetection of this target. Used in TNS reports.' },
             ],
             photometry_items: [
                 { Field: 'target_name<span class="text-danger">*</span>', Description: 'String: Name of the target. Must match the name of a target in the targets section.' },


### PR DESCRIPTION
Frontend changes for: https://github.com/LCOGT/hermes/pull/77

The new fields were placed in the discovery_info subsection of the target as shown in the image below.

![image](https://github.com/LCOGT/hermes-frontend/assets/11946945/5bda5b79-0c48-4b86-aed3-95d29fa986f0)
