### PR TITLE
Fix/tns 2 support

### DIFF
--- a/src/components/message-composition/DataSpectroscopy.vue
+++ b/src/components/message-composition/DataSpectroscopy.vue
@@ -200,7 +200,7 @@
                   desc="Classification of spectroscopic datum"
                   :hide=false
                   :errors="errors.classification"
-                  :options="getTnsValuesList('object_types', true)"
+                  :options="getTnsValuesList('objtypes', true)"
                   @input="update"
               />
             </b-col>

--- a/src/components/message-composition/DiscoveryInfo.vue
+++ b/src/components/message-composition/DiscoveryInfo.vue
@@ -43,6 +43,7 @@
               label="Transient Type:"
               :hide=false
               :options="transientTypes"
+              :errors="errors.transient_type"
               @input="update"
           />
         </b-col>
@@ -109,7 +110,7 @@
     },
     data: function() {
       return {
-        transientTypes: [{value: null, text: ''}, 'AGN', 'FRB', 'NUC', 'Other', 'PNV', 'PSN'],
+        transientTypes: [{value: null, text: ''}, 'AGN - Known AGN', 'FRB - Fast Radio Burst event', 'NUC - Possibly nuclear', 'Other - Undefined', 'PNV - Possible Nova', 'PSN - Possible SN'],
         proprietaryPeriodUnits: ['Days', 'Months', 'Years'],
         show: true,
         id: 'discovery-info-' + this.index

--- a/src/components/message-composition/DiscoveryInfo.vue
+++ b/src/components/message-composition/DiscoveryInfo.vue
@@ -42,7 +42,7 @@
               field="transient_type"
               label="Transient Type:"
               :hide=false
-              :options="transientTypes"
+              :options="getTnsValuesList('at_types', true)"
               :errors="errors.transient_type"
               @input="update"
           />
@@ -110,7 +110,6 @@
     },
     data: function() {
       return {
-        transientTypes: [{value: null, text: ''}, 'AGN - Known AGN', 'FRB - Fast Radio Burst event', 'NUC - Possibly nuclear', 'Other - Undefined', 'PNV - Possible Nova', 'PSN - Possible SN'],
         proprietaryPeriodUnits: ['Days', 'Months', 'Years'],
         show: true,
         id: 'discovery-info-' + this.index

--- a/src/mixins/tnsUtilsMixin.js
+++ b/src/mixins/tnsUtilsMixin.js
@@ -3,12 +3,15 @@ import { mapGetters } from "vuex";
 
 export var tnsUtilsMixin = {
   computed: {
-    ...mapGetters(["getTnsOptions"]),
+    ...mapGetters(["getTnsOptions", "getProfile"]),
   },
   methods: {
     getTnsValuesList: function(category, addNull = false) {
       let tnsOptions = this.getTnsOptions;
       let outputArray = []
+      if (category == 'groups' && this.isHermesBot()){
+        return ['Hermes_group'];
+      }
       if (addNull) {
           outputArray.push({value: null, text: ''})
       }
@@ -18,6 +21,12 @@ export var tnsUtilsMixin = {
       else {
           return outputArray.concat(_.values(tnsOptions[category]).sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'})));
       }
-    }
+    },
+    isHermesBot: function() {
+      if (this.getProfile.tns_bot_name){
+        return false;
+      }
+      return true;
+    },
   }
 };

--- a/src/views/AboutHermes.vue
+++ b/src/views/AboutHermes.vue
@@ -713,7 +713,7 @@ export default {
             discovery_items: [
                 { Field: 'reporting_group<sup class="text-info">&dagger;</sup>', Description: 'String: Reporting Group required for TNS Submission.' },
                 { Field: 'discovery_source<sup class="text-info">&dagger;</sup>', Description: 'String: Discovery Data Source required for TNS Submission.' },
-                { Field: 'transient_type', Description: 'String: Type of transient; Accepted values are [PSN, nuc, PNV, AGN, Other].' },
+                { Field: 'transient_type', Description: 'String: Type of transient; Accepted values are the TNS accepted at_types.' },
                 { Field: 'proprietary_period', Description: 'Float: Length of time discovery should remain proprietary on TNS.' },
                 { Field: 'proprietary_period_unit', Description: 'Sring: Units for proprietary period; [Days, Months, Years].' },
                 { Field: 'nondetection_source', Description: 'String: Source catalog for the last nondetection on this target. Used in TNS reports.' },

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -74,7 +74,7 @@
       <b-col md="4" class="border-top pt-4">
         <h3 class="text-center">TNS Bot Credentials</h3>
         <p>
-          By default, TNS submissions will use the built-in <b>Hermes_bot</b>.
+          By default, TNS submissions will use the built-in <b>Hermes_bot</b>. This bot only has permissions to report to the TNS from the <b>Hermes_group</b>.
           You can override this behaviour and submit with your own TNS Bot credentials by adding then to your profile
           here or via the api.
         </p>


### PR DESCRIPTION
This fixes the tns 2.0 issues. It gets the transient_types from the API, and it restricts the discovery and reporting group options to "Hermes_group" if the user hasn't set a bot and is using the default "Hermes Bot". TNS used to allow any bot to submit as any group, but now restricts it to only groups you are a part of, so the Hermes Bot can only submit to the Hermes_group. 