### PR TITLE
Add ability to include retracted messages and to retract a message of…

### DIFF
--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -19,7 +19,7 @@
                 <template #modal-title>
                   Are you sure you want to retract this message?
                 </template>
-                  Retracted messages are be excluded from hermes queries by default. <b>This operation is not reversible!</b>
+                  Retracted messages are excluded from hermes queries by default. <b>This operation is not reversible!</b>
                 <template #modal-footer="{ ok, cancel }">
                   <b-row class="d-flex justify-content-between" style="width:100%;">
                     <b-button size="sm" variant="outline-primary" @click="cancel()">Cancel</b-button>
@@ -254,7 +254,7 @@ export default {
     showRetractMessage: function() {
       if (this.isLoggedIn) {
         let group = this.message.topic.split(".", 1)[0];
-        if (group in this.getProfile.group_memberships && this.getProfile.group_memberships[group] == 'Owner') {
+        if (group in this.getProfile.group_memberships && this.getProfile.group_memberships[group] === 'Owner') {
           return !this.message.retracted;
         }
       }

--- a/src/views/QueryMessages.vue
+++ b/src/views/QueryMessages.vue
@@ -173,8 +173,7 @@ export default {
         },
       ],
       selectedItem: null,
-      topic: null,
-      includeRetracted: false
+      topic: null
     };
   },
   mounted() {


### PR DESCRIPTION
… a group you are an owner of, and to see if a message is retracted

[hermes_message_retraction.webm](https://github.com/user-attachments/assets/9fa71b56-6877-40fc-97bc-526be4324d9b)

* Note the red button in the filters for retraction is only red when you are including retracted messages - it is just white outlined with red when not including them (the default), but this isn't shown correctly in the video.

Backend changes: https://github.com/LCOGT/hermes/pull/84